### PR TITLE
Add Code Quality Github Actions script

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,24 @@
+name: 'Environment Setup'
+description: 'This GitHub Action sets up the testing environment for the project. This allows us to put all steps in one shared composite action.'
+runs:
+  using: "composite"
+  steps:
+    - name: Load Bun Cache
+      uses: actions/cache@v3
+      with:
+        path: /root/.bun
+        key: ${{ runner.os }}-bun
+
+    - name: Install Bun
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: oven-sh/setup-bun@v1
+
+    - name: Load Dependencies Cache
+      uses: actions/cache@v3
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+
+    - name: Install Dependencies
+      run: bun install
+      shell: bash

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,34 +8,27 @@ on:
     branches:
       - master
 jobs:
-  code_quality:
+  prettier:
+    name: Prettier Validation
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+
+      - name: Prettier Check
+        run: bun x prettier --check .
+  typescript:
     name: TypeScript Compilation
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Load Bun Cache
-        uses: actions/cache@v3
-        with:
-          path: /root/.bun
-          key: ${{ runner.os }}-bun
-
-      - name: Install Bun
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: oven-sh/setup-bun@v1
-
-      - name: Load Dependencies Cache
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
-
-      - name: Install Dependencies
-        run: bun install
-
-      - name: Prettier checks
-        run: bun x prettier --check .
+      - name: Setup Environment
+        uses: ./.github/actions/setup
 
       - name: Compile TypeScript
         run: bun x tsc

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,41 @@
+name: Code Quality
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  code_quality:
+    name: TypeScript Compilation
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Load Bun Cache
+        uses: actions/cache@v3
+        with:
+          path: /root/.bun
+          key: ${{ runner.os }}-bun
+
+      - name: Install Bun
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: oven-sh/setup-bun@v1
+
+      - name: Load Dependencies Cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install Dependencies
+        run: bun install
+
+      - name: Compile TypeScript
+        run: bun x tsc
+
+
+

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install Dependencies
         run: bun install
 
+      - name: Prettier checks
+        run: bun x prettier --check .
+
       - name: Compile TypeScript
         run: bun x tsc
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Environment
         uses: ./.github/actions/setup

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     },
     "devDependencies": {
         "bun-types": "latest",
-        "nodemon": "^3.0.1"
+        "nodemon": "^3.0.1",
+        "prettier": "^3.0.3"
     },
     "peerDependencies": {
         "typescript": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "scripts": {
         "dev": "nodemon -L --exec \"tsc && bun --inspect=9229\" index.ts",
         "start": "bun index.ts",
+        "workflows": "act",
         "pretty": "bunx prettier . --write"
     }
 }


### PR DESCRIPTION
This GitHub action enforces code quality by running the TypeScript compiler and Prettier. If either fail, they will show errors on the commit and in PRs. Developers should probably use the `bun dev` command to see TypeScript errors as they show up, and run `bun x prettier --write <...changed_files>` before their commits. IDEs can also be configured to display TypeScript errors inline and to run Prettier on-save so you don't have to do it manually.

An example run can be found here: https://github.com/robere2/lavacake/actions/runs/6278659499

(The TypeScript run is currently failing because there are TypeScript errors in the master branch)